### PR TITLE
Alternative approach wrt genserver usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   the MPR121 (which defaults to 0x5a) and options.
 
   ~~~ elixir
-  { :ok, device } = Mpr121.start_link("i2c-1")
+  { :ok, device } = Mpr121.start_link(bus: "i2c-1")
   
   bits = Mpr121.touch_state_all(device)  # => 12 bits, one per touch channel
   

--- a/lib/mpr121.ex
+++ b/lib/mpr121.ex
@@ -210,7 +210,7 @@ defmodule Mpr121 do
   end
 
   @doc false
-  def handle_call({ :reset }, state = %{ i2c: i2c }) do
+  def handle_call({ :reset }, _, state = %{ i2c: i2c }) do
     do_reset_mpr121(i2c)
     { :reply, true, state }
   end

--- a/lib/mpr121.ex
+++ b/lib/mpr121.ex
@@ -344,7 +344,7 @@ if Mix.env != :prod do
       Logger.info("write_read #{dump data}")
       result = 0x24..(0x24+len-1) |> Enum.into([])
       Logger.info("\t\t=> #{inspect result}")
-      result
+      to_string(result)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mpr121.Mixfile do
   @version "0.1.0"
   
   @deps [
-    { :elixir_ale, "~> 0.6", only: :prod },
+    { :elixir_ale, "~> 1.2", only: :prod },
   ]
 
   ############################################################


### PR DESCRIPTION
After playing with mpr121 a bit I found that I couldn't easily wrap it into a supervision tree. It has a function `start_link`, but it actually called `GenServer.start`. Then I also couldn't find a reason why it should be a GenServer as it doesn't have its own internal state. Merely a PID for the I2C GenServer. This is an attempt in simplifying this library and just providing an easy-to-use MPR121 API on top of the I2C interface of Elixir/ALE.

Please let me know what you think. Any feedback is appreciated.